### PR TITLE
Added kernel vs user mode time distribution to process info

### DIFF
--- a/sample/src/main/java/com/jaredrummler/android/processes/sample/dialogs/ProcessInfoDialog.java
+++ b/sample/src/main/java/com/jaredrummler/android/processes/sample/dialogs/ProcessInfoDialog.java
@@ -86,6 +86,16 @@ public class ProcessInfoDialog extends DialogFragment {
       } else if (rtPriority >= 1 && rtPriority <= 99) {
         html.p().strong("SCHEDULING PRIORITY: ").append("real-time").close();
       }
+      long userModeTicks = stat.utime();
+      long kernelModeTicks = stat.stime();
+      long percentOfTimeUserMode;
+      long percentOfTimeKernelMode;
+      if ((kernelModeTicks + userModeTicks) > 0) {
+        percentOfTimeUserMode = (userModeTicks * 100) / (userModeTicks + kernelModeTicks);
+        percentOfTimeKernelMode = (kernelModeTicks * 100) / (userModeTicks + kernelModeTicks);
+        html.p().strong("TIME EXECUTED IN USER MODE: ").append(percentOfTimeUserMode + "%").close();
+        html.p().strong("TIME EXECUTED IN KERNEL MODE: ").append(percentOfTimeKernelMode + "%").close();
+      }
     } catch (IOException e) {
       Log.d(TAG, String.format("Error reading /proc/%d/stat.", process.pid));
     }


### PR DESCRIPTION
Used utime() and stime() methods from Stat class to get the number of ticks the process has executed in kernel and user mode respectively. Then simply calculated how much time the process has been executing in each mode in terms of %.
